### PR TITLE
[3.x] Removes failure from aborted transactions.

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Str;
 use Laragear\Transbank\ApiRequest;
 use Laragear\Transbank\Exceptions\ClientException;
 use Laragear\Transbank\Exceptions\NetworkException;
@@ -128,6 +129,16 @@ class Client
         }
 
         if ($response->clientError()) {
+            // If the error is an HTTP 422, we will check if the error contains the "abort" word.
+            // If that word is found, it will mean the transaction was correct, but was aborted.
+            // In that case, we will do nothing, allowing the transaction to still be processed.
+            if (
+                $response->status() === 422 &&
+                Str::contains($this->getErrorMessage($response), 'Transaction has an invalid finished state: aborted'))
+            {
+                return;
+            }
+
             throw new ClientException($this->getErrorMessage($response), $apiRequest, $response);
         }
     }

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -395,6 +395,33 @@ class ClientTest extends TestCase
         );
     }
 
+    public function test_does_not_throws_client_exception_if_response_client_error_is_transaction_aborted(): void
+    {
+        $this->app->make('config')->set('transbank.http.options', ['foo' => 'bar']);
+
+        $this->mock(Factory::class)->expects('withoutRedirecting')->andReturnUsing(
+            static function (): MockInterface {
+                $pending = Mockery::mock(PendingRequest::class)->makePartial();
+
+                $pending->expects('send')->andReturn(
+                    new Response(
+                        new GuzzleResponse(
+                            422, ['content-type' => 'application/json'], json_encode([
+                                'error_message' => 'Transaction has an invalid finished state: aborted'
+                            ])
+                        )
+                    )
+                );
+
+                return $pending;
+            }
+        );
+
+        $this->app->make(Client::class)->send(
+            'post', 'https://endpoint/{api_version}/', new ApiRequest('foo', 'bar', ['foo' => 'bar'])
+        );
+    }
+
     public function test_doesnt_sends_api_data_when_method_is_read(): void
     {
         $this->app->make('config')->set('transbank.http.options', ['foo' => 'bar']);


### PR DESCRIPTION
When a transaction is aborted on Transbank WebPay frontend, it returns back to the commerce. When the transactions by its token is retrieved, the backend will return a HTTP 422 response, saying the transaction is on an unfinished state (aborted).

This fix allows to proceed with the transaction when the status and the message text coincides. Otherwise, it will proceed to throw an exception like always.

Even my cat could make a better API. And it's dead. That's Transbank quality for all its glorified lower commerce fees.